### PR TITLE
Fix award traversal

### DIFF
--- a/openprocurement/tender/openua/utils.py
+++ b/openprocurement/tender/openua/utils.py
@@ -177,6 +177,7 @@ def add_next_award(request, reverse=False):
                         'startDate': now.isoformat()
                     }
                 })
+                award.__parent__ = tender
                 tender.awards.append(award)
                 request.response.headers['Location'] = request.route_url('{}:Tender Awards'.format(tender.procurementMethodType), tender_id=tender.id, award_id=award['id'])
                 statuses.add('pending')
@@ -205,6 +206,7 @@ def add_next_award(request, reverse=False):
                         'startDate': get_now().isoformat()
                     }
                 })
+                award.__parent__ = tender
                 tender.awards.append(award)
                 request.response.headers['Location'] = request.route_url('{}:Tender Awards'.format(tender.procurementMethodType), tender_id=tender.id, award_id=award['id'])
         if tender.awards[-1].status == 'pending':


### PR DESCRIPTION
На serialize-ації Value моделі для esco доступаємся до тендера(одного з його полів). Для новоствореного Award-a бракує "батька".
Приклад де це потрібно:
https://github.com/openprocurement/openprocurement.tender.esco/blob/master/openprocurement/tender/esco/models.py#L151

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openprocurement/openprocurement.tender.openua/71)
<!-- Reviewable:end -->
